### PR TITLE
liuliu/set up app menu

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -4,16 +4,18 @@ import {
   BrowserWindow,
   ipcMain,
   Menu,
-   utilityProcess,
+  utilityProcess,
   UtilityProcess,
- } from "electron";
+} from "electron";
 import serve from "electron-serve";
 import { createWindow } from "./helpers";
 import { initMenu } from "./helpers/menu";
-  
+
 const isProd = process.env.NODE_ENV === "production";
 const userDataPath = app.getPath("userData");
-const schemaPath = isProd?path.join(userDataPath, "schema.gql"):"graphql-server/schema.gql";
+const schemaPath = isProd
+  ? path.join(userDataPath, "schema.gql")
+  : "graphql-server/schema.gql";
 process.env.SCHEMA_PATH = schemaPath;
 process.env.NEXT_PUBLIC_FOR_ELECTRON = "true";
 
@@ -79,13 +81,12 @@ app.on("ready", () => {
 
 function updateMenu(databaseName?: string) {
   const hasChosenDatabase = !!databaseName;
-  const menu = initMenu(mainWindow, isProd,hasChosenDatabase);
- 
-    Menu.setApplicationMenu(menu);
- 
+  const menu = initMenu(mainWindow, isProd, hasChosenDatabase);
+
+  Menu.setApplicationMenu(menu);
 }
 
-ipcMain.on('update-menu', (_event, databaseName?: string) => {
+ipcMain.on("update-menu", (_event, databaseName?: string) => {
   updateMenu(databaseName);
 });
 

--- a/main/background.ts
+++ b/main/background.ts
@@ -3,12 +3,14 @@ import {
   app,
   BrowserWindow,
   ipcMain,
-  utilityProcess,
+  Menu,
+   utilityProcess,
   UtilityProcess,
-} from "electron";
+ } from "electron";
 import serve from "electron-serve";
 import { createWindow } from "./helpers";
-
+import { initMenu } from "./helpers/menu";
+  
 const isProd = process.env.NODE_ENV === "production";
 const userDataPath = app.getPath("userData");
 const schemaPath = isProd?path.join(userDataPath, "schema.gql"):"graphql-server/schema.gql";
@@ -60,21 +62,31 @@ app.on("ready", () => {
       preload: path.join(__dirname, "preload.js"),
     },
   });
+  Menu.setApplicationMenu(initMenu(mainWindow, isProd));
   createGraphqlSeverProcess();
 
   if (isProd) {
     setTimeout(async () => {
       await mainWindow.loadURL("app://./");
-      mainWindow.webContents.openDevTools();
-
     }, 3000);
   } else {
     setTimeout(async () => {
       const port = process.argv[2];
       await mainWindow.loadURL(`http://localhost:${port}`);
-      mainWindow.webContents.openDevTools();
     }, 2500);
   }
+});
+
+function updateMenu(databaseName?: string) {
+  const hasChosenDatabase = !!databaseName;
+  const menu = initMenu(mainWindow, isProd,hasChosenDatabase);
+ 
+    Menu.setApplicationMenu(menu);
+ 
+}
+
+ipcMain.on('update-menu', (_event, databaseName?: string) => {
+  updateMenu(databaseName);
 });
 
 app.on("before-quit", () => {

--- a/main/helpers/create-window.ts
+++ b/main/helpers/create-window.ts
@@ -3,34 +3,34 @@ import {
   BrowserWindow,
   BrowserWindowConstructorOptions,
   Rectangle,
-} from 'electron'
-import Store from 'electron-store'
+} from "electron";
+import Store from "electron-store";
 
 export const createWindow = (
   windowName: string,
-  options: BrowserWindowConstructorOptions
+  options: BrowserWindowConstructorOptions,
 ): BrowserWindow => {
-  const key = 'window-state'
-  const name = `window-state-${windowName}`
-  const store = new Store<Rectangle>({ name })
+  const key = "window-state";
+  const name = `window-state-${windowName}`;
+  const store = new Store<Rectangle>({ name });
   const defaultSize = {
     width: options.width,
     height: options.height,
-  }
-  let state = {}
+  };
+  let state = {};
 
-  const restore = () => store.get(key, defaultSize)
+  const restore = () => store.get(key, defaultSize);
 
   const getCurrentPosition = () => {
-    const position = win.getPosition()
-    const size = win.getSize()
+    const position = win.getPosition();
+    const size = win.getSize();
     return {
       x: position[0],
       y: position[1],
       width: size[0],
       height: size[1],
-    }
-  }
+    };
+  };
 
   const windowWithinBounds = (windowState, bounds) => {
     return (
@@ -38,37 +38,37 @@ export const createWindow = (
       windowState.y >= bounds.y &&
       windowState.x + windowState.width <= bounds.x + bounds.width &&
       windowState.y + windowState.height <= bounds.y + bounds.height
-    )
-  }
+    );
+  };
 
   const resetToDefaults = () => {
-    const bounds = screen.getPrimaryDisplay().bounds
+    const bounds = screen.getPrimaryDisplay().bounds;
     return Object.assign({}, defaultSize, {
       x: (bounds.width - defaultSize.width) / 2,
       y: (bounds.height - defaultSize.height) / 2,
-    })
-  }
+    });
+  };
 
-  const ensureVisibleOnSomeDisplay = (windowState) => {
-    const visible = screen.getAllDisplays().some((display) => {
-      return windowWithinBounds(windowState, display.bounds)
-    })
+  const ensureVisibleOnSomeDisplay = windowState => {
+    const visible = screen.getAllDisplays().some(display => {
+      return windowWithinBounds(windowState, display.bounds);
+    });
     if (!visible) {
       // Window is partially or fully not visible now.
       // Reset it to safe defaults.
-      return resetToDefaults()
+      return resetToDefaults();
     }
-    return windowState
-  }
+    return windowState;
+  };
 
   const saveState = () => {
     if (!win.isMinimized() && !win.isMaximized()) {
-      Object.assign(state, getCurrentPosition())
+      Object.assign(state, getCurrentPosition());
     }
-    store.set(key, state)
-  }
+    store.set(key, state);
+  };
 
-  state = ensureVisibleOnSomeDisplay(restore())
+  state = ensureVisibleOnSomeDisplay(restore());
 
   const win = new BrowserWindow({
     ...state,
@@ -78,9 +78,9 @@ export const createWindow = (
       contextIsolation: true,
       ...options.webPreferences,
     },
-  })
+  });
 
-  win.on('close', saveState)
+  win.on("close", saveState);
 
-  return win
-}
+  return win;
+};

--- a/main/helpers/index.ts
+++ b/main/helpers/index.ts
@@ -1,1 +1,1 @@
-export * from './create-window'
+export * from "./create-window";

--- a/main/helpers/menu.ts
+++ b/main/helpers/menu.ts
@@ -9,7 +9,7 @@ export function initMenu(
   win: BrowserWindow,
   isProd: boolean,
   hasChosenDatabase?: boolean,
-) {
+): Menu {
   var application_menu: MenuItemConstructorOptions[] = [
     {
       label: "Edit",
@@ -86,25 +86,57 @@ export function initMenu(
         },
         {
           label: "Import File",
+          accelerator: "CmdOrCtrl+I",
           click: () => win.webContents.send("menu-clicked", "upload-file"),
           enabled: hasChosenDatabase,
         },
         {
           type: "separator",
-          enabled: hasChosenDatabase,
         },
         {
           label: "Commit Graph",
+          accelerator: "CmdOrCtrl+G",
           click: () => win.webContents.send("menu-clicked", "commit-graph"),
           enabled: hasChosenDatabase,
         },
         {
           type: "separator",
-          enabled: hasChosenDatabase,
         },
         {
           label: "Schema Diagram",
+          accelerator: "CmdOrCtrl+D",
           click: () => win.webContents.send("menu-clicked", "schema-diagram"),
+          enabled: hasChosenDatabase,
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: "New...",
+          submenu: [
+            {
+              label: "Table",
+              accelerator: "CmdOrCtrl+T",
+              click: () => win.webContents.send("menu-clicked", "new-table"),
+              enabled: hasChosenDatabase,
+            },
+            {
+              type: "separator",
+            },
+            {
+              label: "Branch",
+              accelerator: "CmdOrCtrl+B",
+              click: () => win.webContents.send("menu-clicked", "new-branch"),
+            },
+            {
+              type: "separator",
+            },
+            {
+              label: "Release",
+              accelerator: "CmdOrCtrl+R",
+              click: () => win.webContents.send("menu-clicked", "new-release"),
+            },
+          ],
           enabled: hasChosenDatabase,
         },
       ],

--- a/main/helpers/menu.ts
+++ b/main/helpers/menu.ts
@@ -1,130 +1,133 @@
 import {
-    shell,
-    BrowserWindow,
-    Menu,MenuItemConstructorOptions
-  } from "electron";
- 
+  shell,
+  BrowserWindow,
+  Menu,
+  MenuItemConstructorOptions,
+} from "electron";
 
-  export function initMenu(win:BrowserWindow, isProd: boolean,hasChosenDatabase?: boolean,) {
-    var application_menu:MenuItemConstructorOptions[]  = [
-      {
-        label: 'Edit',
-        submenu: [
-           
-          {
-            type: 'separator',
-          },
-          {
-            role: 'cut',
-          },
-          {
-            role: 'copy',
-          },
-          {
-            role: 'paste',
-          },
-          {
-            role: 'pasteAndMatchStyle',
-          },
-          {
-            role: 'delete',
-          },
-          {
-            role: 'selectAll',
-          },
-        ],
-      },
-      {
-        label: 'View',
-        submenu: [
-          isProd
-            ? { label: 'hidden', visible: false }:{
-                label: 'Reload',
-                click(_item, focusedWindow) {
-                  if (focusedWindow) focusedWindow.reload();
-                },
-              }
-            ,
-          isProd
-            ? { label: 'hidden', visible: false }: {
-                type: 'separator',
-              },
-          {
-            role: 'resetZoom',
-          },
-          {
-            role: 'zoomIn',
-          },
-          {
-            role: 'zoomOut',
-          },
-          {
-            type: 'separator',
-          },
-          {
-            role: 'togglefullscreen',
-          },
-        ],
-      },
-      {
-        label: 'Tools',
-        submenu: [
-          {
-            label: 'Toggle Developer Tools',
-            accelerator:
-              process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-            click(_item, focusedWindow) {
-              if (focusedWindow) focusedWindow.webContents.toggleDevTools();
-            },
-          },
+export function initMenu(
+  win: BrowserWindow,
+  isProd: boolean,
+  hasChosenDatabase?: boolean,
+) {
+  var application_menu: MenuItemConstructorOptions[] = [
+    {
+      label: "Edit",
+      submenu: [
         {
-          type: 'separator',
+          type: "separator",
         },
-          {
-            label: "Import File",
-            click: () => win.webContents.send('menu-clicked', "upload-file"),
-            enabled: hasChosenDatabase,
-          },
-          {
-            type: 'separator',
-            enabled: hasChosenDatabase,
-          },
-          {
-            label:"Commit Graph",
-            click: () => win.webContents.send('menu-clicked', "commit-graph"),
-            enabled: hasChosenDatabase,
-          },
-          {
-            type: 'separator',
-            enabled: hasChosenDatabase,
-          },
-          {
-            label:"Schema Diagram",
-            click: () => win.webContents.send('menu-clicked', "schema-diagram"),
-            enabled: hasChosenDatabase,
-          }
-        ],
-      },
-      {
-        role: 'window',
-        submenu: [
-          {
-            role: 'minimize',
-          },
-        ],
-      },
-      {
-        role: 'help',
-        submenu: [
-          {
-            label: 'Learn More',
-            click() {
-              shell.openExternal('https://docs.dolthub.com/');
+        {
+          role: "cut",
+        },
+        {
+          role: "copy",
+        },
+        {
+          role: "paste",
+        },
+        {
+          role: "pasteAndMatchStyle",
+        },
+        {
+          role: "delete",
+        },
+        {
+          role: "selectAll",
+        },
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        isProd
+          ? { label: "hidden", visible: false }
+          : {
+              label: "Reload",
+              click(_item, focusedWindow) {
+                if (focusedWindow) focusedWindow.reload();
+              },
             },
+        isProd
+          ? { label: "hidden", visible: false }
+          : {
+              type: "separator",
+            },
+        {
+          role: "resetZoom",
+        },
+        {
+          role: "zoomIn",
+        },
+        {
+          role: "zoomOut",
+        },
+        {
+          type: "separator",
+        },
+        {
+          role: "togglefullscreen",
+        },
+      ],
+    },
+    {
+      label: "Tools",
+      submenu: [
+        {
+          label: "Toggle Developer Tools",
+          accelerator:
+            process.platform === "darwin" ? "Alt+Command+I" : "Ctrl+Shift+I",
+          click(_item, focusedWindow) {
+            if (focusedWindow) focusedWindow.webContents.toggleDevTools();
           },
-        ],
-      },
-    ];
-       return Menu.buildFromTemplate(application_menu);
-    
-    }
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: "Import File",
+          click: () => win.webContents.send("menu-clicked", "upload-file"),
+          enabled: hasChosenDatabase,
+        },
+        {
+          type: "separator",
+          enabled: hasChosenDatabase,
+        },
+        {
+          label: "Commit Graph",
+          click: () => win.webContents.send("menu-clicked", "commit-graph"),
+          enabled: hasChosenDatabase,
+        },
+        {
+          type: "separator",
+          enabled: hasChosenDatabase,
+        },
+        {
+          label: "Schema Diagram",
+          click: () => win.webContents.send("menu-clicked", "schema-diagram"),
+          enabled: hasChosenDatabase,
+        },
+      ],
+    },
+    {
+      role: "window",
+      submenu: [
+        {
+          role: "minimize",
+        },
+      ],
+    },
+    {
+      role: "help",
+      submenu: [
+        {
+          label: "Learn More",
+          click() {
+            shell.openExternal("https://docs.dolthub.com/");
+          },
+        },
+      ],
+    },
+  ];
+  return Menu.buildFromTemplate(application_menu);
+}

--- a/main/helpers/menu.ts
+++ b/main/helpers/menu.ts
@@ -1,0 +1,130 @@
+import {
+    shell,
+    BrowserWindow,
+    Menu,MenuItemConstructorOptions
+  } from "electron";
+ 
+
+  export function initMenu(win:BrowserWindow, isProd: boolean,hasChosenDatabase?: boolean,) {
+    var application_menu:MenuItemConstructorOptions[]  = [
+      {
+        label: 'Edit',
+        submenu: [
+           
+          {
+            type: 'separator',
+          },
+          {
+            role: 'cut',
+          },
+          {
+            role: 'copy',
+          },
+          {
+            role: 'paste',
+          },
+          {
+            role: 'pasteAndMatchStyle',
+          },
+          {
+            role: 'delete',
+          },
+          {
+            role: 'selectAll',
+          },
+        ],
+      },
+      {
+        label: 'View',
+        submenu: [
+          isProd
+            ? { label: 'hidden', visible: false }:{
+                label: 'Reload',
+                click(_item, focusedWindow) {
+                  if (focusedWindow) focusedWindow.reload();
+                },
+              }
+            ,
+          isProd
+            ? { label: 'hidden', visible: false }: {
+                type: 'separator',
+              },
+          {
+            role: 'resetZoom',
+          },
+          {
+            role: 'zoomIn',
+          },
+          {
+            role: 'zoomOut',
+          },
+          {
+            type: 'separator',
+          },
+          {
+            role: 'togglefullscreen',
+          },
+        ],
+      },
+      {
+        label: 'Tools',
+        submenu: [
+          {
+            label: 'Toggle Developer Tools',
+            accelerator:
+              process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+            click(_item, focusedWindow) {
+              if (focusedWindow) focusedWindow.webContents.toggleDevTools();
+            },
+          },
+        {
+          type: 'separator',
+        },
+          {
+            label: "Import File",
+            click: () => win.webContents.send('menu-clicked', "upload-file"),
+            enabled: hasChosenDatabase,
+          },
+          {
+            type: 'separator',
+            enabled: hasChosenDatabase,
+          },
+          {
+            label:"Commit Graph",
+            click: () => win.webContents.send('menu-clicked', "commit-graph"),
+            enabled: hasChosenDatabase,
+          },
+          {
+            type: 'separator',
+            enabled: hasChosenDatabase,
+          },
+          {
+            label:"Schema Diagram",
+            click: () => win.webContents.send('menu-clicked', "schema-diagram"),
+            enabled: hasChosenDatabase,
+          }
+        ],
+      },
+      {
+        role: 'window',
+        submenu: [
+          {
+            role: 'minimize',
+          },
+        ],
+      },
+      {
+        role: 'help',
+        submenu: [
+          {
+            label: 'Learn More',
+            click() {
+              shell.openExternal('https://docs.dolthub.com/');
+            },
+          },
+        ],
+      },
+    ];
+       return Menu.buildFromTemplate(application_menu);
+    
+    }

--- a/main/helpers/menu.ts
+++ b/main/helpers/menu.ts
@@ -10,7 +10,7 @@ export function initMenu(
   isProd: boolean,
   hasChosenDatabase?: boolean,
 ): Menu {
-  var application_menu: MenuItemConstructorOptions[] = [
+  var applicationMenu: MenuItemConstructorOptions[] = [
     {
       label: "Edit",
       submenu: [
@@ -161,5 +161,5 @@ export function initMenu(
       ],
     },
   ];
-  return Menu.buildFromTemplate(application_menu);
+  return Menu.buildFromTemplate(applicationMenu);
 }

--- a/main/preload.d.ts
+++ b/main/preload.d.ts
@@ -1,7 +1,7 @@
 declare const handler: {
-    send(channel: string, value: unknown): void;
-    on(channel: string, callback: (...args: unknown[]) => void): () => void;
-    invoke(channel: string, ...args: unknown[]): Promise<any>;
+  send(channel: string, value: unknown): void;
+  on(channel: string, callback: (...args: unknown[]) => void): () => void;
+  invoke(channel: string, ...args: unknown[]): Promise<any>;
 };
 export type IpcHandler = typeof handler;
 export {};

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -4,8 +4,12 @@ const handler = {
   invoke(channel: string, ...args: unknown[]) {
     return ipcRenderer.invoke(channel, ...args);
   },
+  onMenuClicked: (callback:(value:string)=>{}) => ipcRenderer.on('menu-clicked', (_event, value) => callback(value)),
+  updateAppMenu: (databaseName?: string) => {
+    ipcRenderer.send('update-menu', databaseName);
+  },
 };
 
 contextBridge.exposeInMainWorld("ipc", handler);
-
+ 
 export type IpcHandler = typeof handler;

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -4,12 +4,13 @@ const handler = {
   invoke(channel: string, ...args: unknown[]) {
     return ipcRenderer.invoke(channel, ...args);
   },
-  onMenuClicked: (callback:(value:string)=>{}) => ipcRenderer.on('menu-clicked', (_event, value) => callback(value)),
+  onMenuClicked: (callback: (value: string) => {}) =>
+    ipcRenderer.on("menu-clicked", (_event, value) => callback(value)),
   updateAppMenu: (databaseName?: string) => {
-    ipcRenderer.send('update-menu', databaseName);
+    ipcRenderer.send("update-menu", databaseName);
   },
 };
 
 contextBridge.exposeInMainWorld("ipc", handler);
- 
+
 export type IpcHandler = typeof handler;

--- a/web/components/pageComponents/DatabasePage/component.tsx
+++ b/web/components/pageComponents/DatabasePage/component.tsx
@@ -2,7 +2,15 @@ import DatabaseLayout from "@components/layouts/DatabaseLayout";
 import { SqlEditorProvider } from "@contexts/sqleditor";
 import useDefaultBranch from "@hooks/useDefaultBranch";
 import { DatabasePageParams } from "@lib/params";
-import { commitGraph, createTable, newBranch, newRelease, RefUrl, schemaDiagram, upload } from "@lib/urls";
+import {
+  commitGraph,
+  createTable,
+  newBranch,
+  newRelease,
+  RefUrl,
+  schemaDiagram,
+  upload,
+} from "@lib/urls";
 import { useRouter } from "next/router";
 import { ReactNode } from "react";
 
@@ -54,7 +62,7 @@ export default function DatabasePage({ params, children, ...props }: Props) {
           break;
         }
         case "new-branch": {
-          const { href, as } =newBranch(paramsWithRef);
+          const { href, as } = newBranch(paramsWithRef);
           router.push(href, as).catch(console.error);
           break;
         }

--- a/web/components/pageComponents/DatabasePage/component.tsx
+++ b/web/components/pageComponents/DatabasePage/component.tsx
@@ -1,17 +1,8 @@
 import DatabaseLayout from "@components/layouts/DatabaseLayout";
 import { SqlEditorProvider } from "@contexts/sqleditor";
-import useDefaultBranch from "@hooks/useDefaultBranch";
+import useElectronMenu from "@hooks/useElectronMenu";
 import { DatabasePageParams } from "@lib/params";
-import {
-  commitGraph,
-  createTable,
-  newBranch,
-  newRelease,
-  RefUrl,
-  schemaDiagram,
-  upload,
-} from "@lib/urls";
-import { useRouter } from "next/router";
+import { RefUrl } from "@lib/urls";
 import { ReactNode } from "react";
 
 type Props = {
@@ -31,51 +22,7 @@ type Props = {
 };
 
 export default function DatabasePage({ params, children, ...props }: Props) {
-  const router = useRouter();
-  const { defaultBranchName } = useDefaultBranch(params);
-  // route to the correct page based on the menu item clicked
-  if (process.env.NEXT_PUBLIC_FOR_ELECTRON === "true") {
-    window.ipc.onMenuClicked(async (value: string) => {
-      const paramsWithRef = {
-        ...params,
-        refName: params.refName || defaultBranchName,
-      };
-      switch (value) {
-        case "upload-file": {
-          const { href, as } = upload(paramsWithRef);
-          router.push(href, as).catch(console.error);
-          break;
-        }
-        case "commit-graph": {
-          const { href, as } = commitGraph(paramsWithRef);
-          router.push(href, as).catch(console.error);
-          break;
-        }
-        case "schema-diagram": {
-          const { href, as } = schemaDiagram(paramsWithRef);
-          router.push(href, as).catch(console.error);
-          break;
-        }
-        case "new-table": {
-          const { href, as } = createTable(paramsWithRef);
-          router.push(href, as).catch(console.error);
-          break;
-        }
-        case "new-branch": {
-          const { href, as } = newBranch(paramsWithRef);
-          router.push(href, as).catch(console.error);
-          break;
-        }
-        case "new-release": {
-          const { href, as } = newRelease(paramsWithRef);
-          router.push(href, as).catch(console.error);
-          break;
-        }
-        default:
-          break;
-      }
-    });
-  }
+  useElectronMenu(params);
 
   return (
     <SqlEditorProvider params={params}>

--- a/web/components/pageComponents/DatabasePage/component.tsx
+++ b/web/components/pageComponents/DatabasePage/component.tsx
@@ -2,7 +2,7 @@ import DatabaseLayout from "@components/layouts/DatabaseLayout";
 import { SqlEditorProvider } from "@contexts/sqleditor";
 import useDefaultBranch from "@hooks/useDefaultBranch";
 import { DatabasePageParams } from "@lib/params";
-import { commitGraph, RefUrl, schemaDiagram, upload } from "@lib/urls";
+import { commitGraph, createTable, newBranch, newRelease, RefUrl, schemaDiagram, upload } from "@lib/urls";
 import { useRouter } from "next/router";
 import { ReactNode } from "react";
 
@@ -45,6 +45,21 @@ export default function DatabasePage({ params, children, ...props }: Props) {
         }
         case "schema-diagram": {
           const { href, as } = schemaDiagram(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        case "new-table": {
+          const { href, as } = createTable(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        case "new-branch": {
+          const { href, as } =newBranch(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        case "new-release": {
+          const { href, as } = newRelease(paramsWithRef);
           router.push(href, as).catch(console.error);
           break;
         }

--- a/web/hooks/useElectronMenu.ts
+++ b/web/hooks/useElectronMenu.ts
@@ -1,0 +1,59 @@
+import { DatabasePageParams } from "@lib/params";
+import {
+  commitGraph,
+  createTable,
+  newBranch,
+  newRelease,
+  schemaDiagram,
+  upload,
+} from "@lib/urls";
+import { useRouter } from "next/router";
+import useDefaultBranch from "@hooks/useDefaultBranch";
+
+export default function useElectronMenu(params: DatabasePageParams) {
+  const router = useRouter();
+  const { defaultBranchName } = useDefaultBranch(params);
+
+  if (process.env.NEXT_PUBLIC_FOR_ELECTRON === "true") {
+    window.ipc.onMenuClicked(async (value: string) => {
+      const paramsWithRef = {
+        ...params,
+        refName: params.refName || defaultBranchName,
+      };
+      switch (value) {
+        case "upload-file": {
+          const { href, as } = upload(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        case "commit-graph": {
+          const { href, as } = commitGraph(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        case "schema-diagram": {
+          const { href, as } = schemaDiagram(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        case "new-table": {
+          const { href, as } = createTable(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        case "new-branch": {
+          const { href, as } = newBranch(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        case "new-release": {
+          const { href, as } = newRelease(paramsWithRef);
+          router.push(href, as).catch(console.error);
+          break;
+        }
+        default:
+          break;
+      }
+    });
+  }
+}

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -26,8 +26,10 @@ function Inner(props: { pageProps: any; Component: any }) {
   const { params } = props.pageProps;
 
   useEffect(() => {
-    // enable the tools when the database is selected
-    window.ipc.updateAppMenu(params?.databaseName);
+    if (process.env.NEXT_PUBLIC_FOR_ELECTRON === "true") {
+      // enable the tools when the database is selected
+      window.ipc.updateAppMenu(params?.databaseName);
+    }
   }, [props.pageProps]);
 
   const WrappedPage = withApollo(graphqlApiUrl)(props.Component);

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -10,6 +10,7 @@ import "github-markdown-css/github-markdown-light.css";
 import App from "next/app";
 import { SWRConfig } from "swr";
 import "../styles/global.css";
+import { useEffect } from "react";
 
 // configure fetch for use with SWR
 const fetcher = async (input: RequestInfo, init: RequestInit) => {
@@ -22,6 +23,13 @@ const fetcher = async (input: RequestInfo, init: RequestInit) => {
 
 function Inner(props: { pageProps: any; Component: any }) {
   const { graphqlApiUrl } = useServerConfig();
+  const { params } = props.pageProps;
+
+  useEffect(() => {
+    // enable the tools when the database is selected
+    window.ipc.updateAppMenu(params?.databaseName);
+  }, [props.pageProps]);
+
   const WrappedPage = withApollo(graphqlApiUrl)(props.Component);
   return <WrappedPage {...props.pageProps} />;
 }


### PR DESCRIPTION
Changes:

In main process:
- In `preload.ts`, add 2 API to `contextBridge`: `onMenuClicked` and `updateAppMenu`
- In `helpers/menu.ts`, `initMenu` will create the Menu object based on prod/dev, and if database is selected.
- In `background.ts`, call `setApplicationMenu` to set up menu, note that this only works for mac, windows has different menu set up. 
- Update menu when received `update-menu` message from renderer process, this is when database selected state is changed.

In renderer process:
- in `pages/_app.tsx`, send databaseName to main if pageProps changes.
- in `components/pageComponents/component.tsx`, listen on menu clicked, then route to the page based on menu item value.